### PR TITLE
SSH.NET 2023.0.1 update and more tests

### DIFF
--- a/SshNet.PuttyKeyFile.Tests/PuttyKeyFileTest.cs
+++ b/SshNet.PuttyKeyFile.Tests/PuttyKeyFileTest.cs
@@ -2,7 +2,10 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
+
 using Renci.SshNet.Security;
 
 namespace SshNet.PuttyKeyFile.Tests
@@ -14,7 +17,7 @@ namespace SshNet.PuttyKeyFile.Tests
         {
         }
 
-        private void TestKey<TKey>(string keyName, string comment, int keyLength = 0, string? pass = null) where TKey : Key, new()
+        private void TestKey<TKey>(string keyName, string comment, int keyLength = 0, string? pass = null) where TKey : Key
         {
             var keyStream = GetKey($"{keyName}.ppk");
             if (keyStream is null)
@@ -22,65 +25,76 @@ namespace SshNet.PuttyKeyFile.Tests
 
             var keyFile = new PuttyKeyFile(keyStream, pass);
 
-            Assert.IsInstanceOf<TKey>(((KeyHostAlgorithm) keyFile.HostKeyAlgorithms.First()).Key);
-            Assert.AreEqual(keyLength, ((KeyHostAlgorithm) keyFile.HostKeyAlgorithms.First()).Key.KeyLength);
-            Assert.AreEqual(comment, ((KeyHostAlgorithm) keyFile.HostKeyAlgorithms.First()).Key.Comment);
+            ClassicAssert.IsInstanceOf<TKey>(((KeyHostAlgorithm)keyFile.HostKeyAlgorithms.First()).Key);
+            ClassicAssert.AreEqual(keyLength, ((KeyHostAlgorithm)keyFile.HostKeyAlgorithms.First()).Key.KeyLength);
+            ClassicAssert.AreEqual(comment, ((KeyHostAlgorithm)keyFile.HostKeyAlgorithms.First()).Key.Comment);
+        }
+
+        private void TestKeyFail<TKey>(string keyName, string? pass = null) where TKey : Key
+        {
+            var keyStream = GetKey($"{keyName}.ppk");
+            if (keyStream is null)
+                throw new NullReferenceException(nameof(keyStream));
+
+            //Renci.SshNet.Common.SshException: 'Invalid PuTTY private key'
+            Assert.Throws(Is.TypeOf<Renci.SshNet.Common.SshException>()
+                .And.Message.EqualTo("Invalid PuTTY private key"),
+            () => _ = new PuttyKeyFile(keyStream, pass));
+        }
+
+        private void DoTests<TKey>(string keyName, string encKeyName, string comment, int keyLength = 0, string? pass = null) where TKey : Key
+        {
+            TestKey<TKey>(keyName, comment, keyLength);
+            TestKey<TKey>(encKeyName, comment, keyLength, pass);
+            TestKeyFail<TKey>(encKeyName, Guid.NewGuid().ToString());
         }
 
         [Test]
         public void Test_RSA2048()
         {
-            TestKey<RsaKey>("rsa2048", "rsa-key-20210312", 2048);
-            TestKey<RsaKey>("rsa2048pass", "rsa-key-20210312", 2048, "12345");
+            DoTests<RsaKey>("rsa2048", "rsa2048pass", "rsa-key-20210312", 2048, "12345");
         }
 
         [Test]
         public void Test_RSA3072()
         {
-            TestKey<RsaKey>("rsa3072", "rsa-key-20210312", 3072);
-            TestKey<RsaKey>("rsa3072pass", "rsa-key-20210312", 3072, "12345");
+            DoTests<RsaKey>("rsa3072","rsa3072pass", "rsa-key-20210312", 3072, "12345");
         }
 
         [Test]
         public void Test_RSA4096()
         {
-            TestKey<RsaKey>("rsa4096", "rsa-key-20210312", 4096);
-            TestKey<RsaKey>("rsa4096pass", "rsa-key-20210312", 4096, "12345");
+            DoTests<RsaKey>("rsa4096","rsa4096pass", "rsa-key-20210312", 4096, "12345");
         }
 
         [Test]
         public void Test_RSA8192()
         {
-            TestKey<RsaKey>("rsa8192", "rsa-key-20210312", 8192);
-            TestKey<RsaKey>("rsa8192pass", "rsa-key-20210312", 8192, "12345");
+            DoTests<RsaKey>("rsa8192","rsa8192pass", "rsa-key-20210312", 8192, "12345");
         }
 
         [Test]
         public void Test_ECDSA256()
         {
-            TestKey<EcdsaKey>("ecdsa256", "ecdsa-key-20210312", 256);
-            TestKey<EcdsaKey>("ecdsa256pass", "ecdsa-key-20210312", 256, "12345");
+            DoTests<EcdsaKey>("ecdsa256","ecdsa256pass", "ecdsa-key-20210312", 256, "12345");
         }
 
         [Test]
         public void Test_ECDSA384()
         {
-            TestKey<EcdsaKey>("ecdsa384", "ecdsa-key-20210312", 384);
-            TestKey<EcdsaKey>("ecdsa384pass", "ecdsa-key-20210312", 384, "12345");
+            DoTests<EcdsaKey>("ecdsa384","ecdsa384pass", "ecdsa-key-20210312", 384, "12345");
         }
 
         [Test]
         public void Test_ECDSA521()
         {
-            TestKey<EcdsaKey>("ecdsa521", "ecdsa-key-20210312", 521);
-            TestKey<EcdsaKey>("ecdsa521pass", "ecdsa-key-20210312", 521, "12345");
+            DoTests<EcdsaKey>("ecdsa521","ecdsa521pass", "ecdsa-key-20210312", 521, "12345");
         }
 
         [Test]
         public void Test_ED25519()
         {
-            TestKey<ED25519Key>("ed25519", "ed25519-key-20210312", 256);
-            TestKey<ED25519Key>("ed25519pass", "ed25519-key-20210312", 256, "12345");
+            DoTests<ED25519Key>("ed25519","ed25519pass", "ed25519-key-20210312", 256, "12345");
         }
 
         private static Stream? GetKey(string keyName)

--- a/SshNet.PuttyKeyFile.Tests/SshNet.PuttyKeyFile.Tests.csproj
+++ b/SshNet.PuttyKeyFile.Tests/SshNet.PuttyKeyFile.Tests.csproj
@@ -9,9 +9,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="NUnit" Version="3.12.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+        <PackageReference Include="NUnit" Version="4.0.1" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/SshNet.PuttyKeyFile/PuttyKeyFile.cs
+++ b/SshNet.PuttyKeyFile/PuttyKeyFile.cs
@@ -86,7 +86,7 @@ namespace SshNet.PuttyKeyFile
                         throw new SshPassPhraseNullOrEmptyException("Private key is encrypted but passphrase is empty.");
 
                     var cipherKey = GetCipherKey(passPhrase, 32);
-                    var cipher = new AesCipher(cipherKey, new CbcCipherMode(new byte[cipherKey.Length]), new PKCS7Padding());
+                    var cipher = new AesCipher(cipherKey, new byte[cipherKey.Length], AesCipherMode.CBC);
 
                     var privateKeyData = Convert.FromBase64String(privateLines);
                     if (privateKeyData.Length % cipher.BlockSize != 0)
@@ -162,7 +162,7 @@ namespace SshNet.PuttyKeyFile
                 case "ssh-ed25519":
                     publicKey = publicKeyReader.ReadBignum2();
                     unencryptedPrivateKey = privateKeyReader.ReadBignum2();
-                    parsedKey = new ED25519Key(publicKey.Reverse(), unencryptedPrivateKey);
+                    parsedKey = new ED25519Key(unencryptedPrivateKey);
                     break;
                 case "ecdsa-sha2-nistp256":
                 case "ecdsa-sha2-nistp384":

--- a/SshNet.PuttyKeyFile/SshNet.PuttyKeyFile.csproj
+++ b/SshNet.PuttyKeyFile/SshNet.PuttyKeyFile.csproj
@@ -20,6 +20,6 @@
 
     <ItemGroup>
         <PackageReference Include="SshNet.Security.Cryptography" Version="[1.3.0]" />
-        <PackageReference Include="SSH.NET" Version="2023.0.0" />
+        <PackageReference Include="SSH.NET" Version="2023.0.1" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Update NuGet packages, including SSH.NET 2023.0.1
Fix compile errors relating to 2023.0.1 changes
Add a text to verify that loading encrypted keys fails with the wrong password